### PR TITLE
fix: move email config to secrets and fix devcontainer mise setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,33 +1,29 @@
 FROM debian:trixie-slim
 
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
+# Install system dependencies:
+# - ca-certificates: SSL/TLS for HTTPS connections
+# - curl: downloading mise
+# - git: version control
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install essential packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  ca-certificates \
-  curl \
-  git \
-  sudo \
-  && rm -rf /var/lib/apt/lists/*
+# Install mise (polyglot version manager — reads .mise.toml)
+RUN curl https://mise.run | sh
+ENV PATH="/root/.local/bin:$PATH"
 
-# Create non-root user
-RUN groupadd --gid $USER_GID $USERNAME \
-  && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
-  && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
-  && chmod 0440 /etc/sudoers.d/$USERNAME
+# Install tools from .mise.toml (bun, hugo — single source of truth)
+# Also set as global config so mise shims resolve in any directory during build
+COPY .mise.toml /tmp/.mise.toml
+RUN cd /tmp && mise trust . && mise install \
+    && mkdir -p ~/.config/mise && cp .mise.toml ~/.config/mise/config.toml \
+    && rm .mise.toml
+ENV PATH="/root/.local/share/mise/shims:$PATH"
 
-USER $USERNAME
+# Trust workspace so mise doesn't prompt when the repo is bind-mounted at runtime
+ENV MISE_TRUSTED_CONFIG_PATHS="/workspace"
 
-# Install mise (tool version manager)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://mise.run | sh
-ENV PATH="/home/${USERNAME}/.local/bin:${PATH}"
-
-# Copy .mise.toml and install tools
-COPY --chown=${USERNAME}:${USERNAME} .mise.toml /home/${USERNAME}/.mise.toml
-RUN cd /home/${USERNAME} && mise install
-
-# Add mise shims to PATH
-RUN mise reshim
-ENV PATH="/home/${USERNAME}/.local/share/mise/shims:${PATH}"
+WORKDIR /workspace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,8 @@ The contact form requires:
 3. **Worker Secrets** - Set via `wrangler secret put`:
    - `RESEND_API_KEY` - Resend API key for sending emails
    - `TURNSTILE_SECRET_KEY` - Turnstile secret for verification
+   - `TO_EMAIL` - Email recipient for contact form submissions
+   - `FROM_EMAIL` - Email sender (must be from a verified domain in Resend)
 
 ## Deployment
 

--- a/services/email-worker/wrangler.jsonc
+++ b/services/email-worker/wrangler.jsonc
@@ -7,10 +7,6 @@
     "nodejs_compat"
   ],
   "vars": {
-    // Email recipient - where contact form submissions are sent
-    "TO_EMAIL": "hello@example.com",
-    // Email sender - must be from a verified domain in Resend
-    "FROM_EMAIL": "contact@example.com",
     // Allowed CORS origin for the contact form
     "ALLOWED_ORIGIN": "https://gatezh.com"
   },
@@ -23,4 +19,6 @@
   // Secrets (set via `wrangler secret put`):
   // - RESEND_API_KEY: Your Resend API key
   // - TURNSTILE_SECRET_KEY: Your Cloudflare Turnstile secret key
+  // - TO_EMAIL: Email recipient for contact form submissions
+  // - FROM_EMAIL: Email sender (must be from a verified domain in Resend)
 }


### PR DESCRIPTION
- Remove TO_EMAIL/FROM_EMAIL placeholder values from wrangler.jsonc vars (contact form was failing because Resend rejects unverified example.com)
- Document TO_EMAIL/FROM_EMAIL as wrangler secrets alongside existing ones
- Fix devcontainer Dockerfile to match template pattern: trust .mise.toml, copy to global config, and set MISE_TRUSTED_CONFIG_PATHS so hugo/bun shims resolve correctly